### PR TITLE
Make it pass desktop-file-validate

### DIFF
--- a/usr/share/applications/mki3dgame.desktop
+++ b/usr/share/applications/mki3dgame.desktop
@@ -4,4 +4,4 @@ Type=Application
 Icon=mkisg_icon_48x48
 Terminal=true
 Exec=mki3dgame
-Categories=Game
+Categories=Game;


### PR DESCRIPTION
Otherwise we get 

`mki3dgame.desktop: error: value "Game" for string list key "Categories" in group "Desktop Entry" does not have a semicolon (';') as trailing character`

Reference:
https://travis-ci.org/AppImage/AppImageHub/builds/266345343